### PR TITLE
Categoryテーブルのカラム名titleをnameに修正

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,5 +2,5 @@
 
 class Category < ApplicationRecord
   has_many :ideas
-  validates :title, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/db/migrate/20201113160147_rename_title_column_to_categories.rb
+++ b/db/migrate/20201113160147_rename_title_column_to_categories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameTitleColumnToCategories < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :categories, :title, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,12 +12,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_131840) do
+ActiveRecord::Schema.define(version: 2020_11_13_160147) do
   create_table "categories", force: :cascade do |t|
-    t.string "title", null: false
+    t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["title"], name: "index_categories_on_title", unique: true
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
   create_table "ideas", force: :cascade do |t|

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :category do
-    sequence(:title) { |n| "category#{n}" }
+    sequence(:name) { |n| "category#{n}" }
 
     after(:create) do |category|
       create_list(:idea, 3, category: category)

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -7,25 +7,25 @@ RSpec.describe Category, type: :model do
 
   describe "Category" do
     describe "バリデーションチェック" do
-      it "titleが設定されていればOK" do
+      it "nameが設定されていればOK" do
         expect(category.valid?).to eq(true)
       end
 
-      it "titleが空文字だとNG" do
-        category.title = ""
+      it "nameが空文字だとNG" do
+        category.name = ""
         expect(category.valid?).to eq(false)
       end
 
-      it "titleがnilだとNG" do
-        category.title = nil
+      it "nameがnilだとNG" do
+        category.name = nil
         expect(category.valid?).to eq(false)
       end
     end
 
     describe "ユニーク制約チェック" do
-      it "titleが一意であることを確認" do
-        category = Category.create(title: "test")
-        dup_category = Category.create(title: category.title)
+      it "nameが一意であることを確認" do
+        category = Category.create(name: "test")
+        dup_category = Category.create(name: category.name)
         expect(dup_category).not_to be_valid
       end
     end


### PR DESCRIPTION
Categoryテーブルのカラム名が誤っていたため修正。（titleをnameに変更）
