### PR TITLE
アイデア登録機能の追加

### DIFF
--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V1
+    class IdeasController < ApplicationController
+      def create
+        idea = Idea.new(idea_params)
+        if !(params[:category_name].blank? || params[:body].blank?)
+          category = Category.find_or_create_by(name: params[:category_name])
+          idea.category_id = category.id
+        end
+
+        if idea.save
+          render status: 201, json: { status: :created, data: idea }
+        else
+          render status: 422, json: { status: :unprocessable_entity, data: idea.errors }
+        end
+      end
+
+      private
+      def idea_params
+        params.permit(:body, :category_id)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module V1
     class IdeasController < ApplicationController
@@ -16,9 +18,9 @@ module Api
       end
 
       private
-      def idea_params
-        params.permit(:body, :category_id)
-      end
+        def idea_params
+          params.permit(:body, :category_id)
+        end
     end
   end
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -2,5 +2,5 @@
 
 class Idea < ApplicationRecord
   belongs_to :category
-  validates :body, presence: true, uniqueness: true
+  validates :body, presence: true
 end

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"

--- a/bin/rails
+++ b/bin/rails
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  # バージョン管理をわかりやすくために、名前空間の作成
+  namespace 'api' do
+    namespace 'v1' do
+      resources :ideas
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@
 
 Rails.application.routes.draw do
   # バージョン管理をわかりやすくために、名前空間の作成
-  namespace 'api' do
-    namespace 'v1' do
+  namespace "api" do
+    namespace "v1" do
       resources :ideas
     end
   end

--- a/db/migrate/20201114085156_change_category_id_to_idea.rb
+++ b/db/migrate/20201114085156_change_category_id_to_idea.rb
@@ -1,0 +1,5 @@
+class ChangeCategoryIdToIdea < ActiveRecord::Migration[6.0]
+  def change
+    change_column :ideas, :category_id, :bigint
+  end
+end

--- a/db/migrate/20201114085156_change_category_id_to_idea.rb
+++ b/db/migrate/20201114085156_change_category_id_to_idea.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeCategoryIdToIdea < ActiveRecord::Migration[6.0]
   def change
     change_column :ideas, :category_id, :bigint

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_11_14_085156) do
-
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_160147) do
+ActiveRecord::Schema.define(version: 2020_11_14_085156) do
+
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -22,7 +21,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_160147) do
 
   create_table "ideas", force: :cascade do |t|
     t.text "body", null: false
-    t.integer "category_id", null: false
+    t.bigint "category_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["category_id"], name: "index_ideas_on_category_id"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -3,9 +3,5 @@
 FactoryBot.define do
   factory :category do
     sequence(:name) { |n| "category#{n}" }
-
-    after(:create) do |category|
-      create_list(:idea, 3, category: category)
-    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,11 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+# logger
+Rails.logger = Logger.new(STDOUT)
+ActiveRecord::Base.logger = Logger.new(STDOUT)
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/requests/api/v1/ideas_request_spec.rb
+++ b/spec/requests/api/v1/ideas_request_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe "IdeasAPI", type: :request do
+  describe "Create" do
+    context "paramsが存在する場合" do
+      it "既存のCategoryに新しいIdeaを追加する" do
+        # Categoryは追加されず、Ideaは追加される
+        category = create(:category)
+        expect {
+          post "/api/v1/ideas", params: { category_name: category.name, body: "idea" }
+        }.to change(Category, :count).by(0).and change(Idea, :count).by(+1)
+        expect(response.status).to eq(201)
+      end
+
+      it "CategoryとIdeaの両方を新規作成する" do
+        # CategoryもIdeaも追加される
+        expect {
+          post "/api/v1/ideas", params: { category_name: "category", body: "idea" }
+        }.to change(Category, :count).by(+1).and change(Idea, :count).by(+1)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "paramsが空文字の場合" do
+      it "category_nameが空文字" do
+        expect {
+          post "/api/v1/ideas", params: { category_name: "", body: "idea" }
+        }.to change(Category, :count).by(0).and change(Idea, :count).by(0)
+        expect(response.status).to eq(422)
+      end
+      it "ideaのbodyが空文字" do
+        expect {
+          post "/api/v1/ideas", params: { category_name: "category", body: "" }
+        }.to change(Category, :count).by(0).and change(Idea, :count).by(0)
+        expect(response.status).to eq(422)
+      end
+      it "category_name、ideaのbodyが両方空文字" do
+        expect {
+          post "/api/v1/ideas", params: { category_name: "", body: "" }
+        }.to change(Category, :count).by(0).and change(Idea, :count).by(0)
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/ideas_request_spec.rb
+++ b/spec/requests/api/v1/ideas_request_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe "IdeasAPI", type: :request do
   describe "Create" do


### PR DESCRIPTION
アイデア登録機能を追加するため、createアクションを作成
【リクエスト】
・category_name(カテゴリー名):string null: false
・body(本文):string null: false

①リクエストのcategory_nameがcategoriesテーブルのnameに存在する場合
→categoryのidをcategory_idとしてideasテーブルに登録し、ステータスコード201を返却
②リクエストのcategory_nameがcategoriesテーブルのnameに存在しない場合
→新たなcategoryとしてcategoriesテーブルに登録後、ideasテーブルに登録し、ステータスコード201を返却
③リクエストが空の場合
→422エラーを返却（バリデーションエラー）

他、以下作業を実行。
・ルーティングの設定
・Ideaモデルbodyカラムのユニーク制約が不要なため削除
・Ideaモデルcategory_idカラムのデータ型を、integerからbigintに変更
・requestスペックの作成