### PR TITLE
アイデア取得機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ group :development do
   gem "rubocop-packaging", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
+
+  gem "bullet"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,9 @@ GEM
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -192,6 +195,7 @@ GEM
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    uniform_notifier (1.13.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -202,6 +206,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
+  bullet
   byebug
   factory_bot_rails
   listen (~> 3.2)

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -3,6 +3,20 @@
 module Api
   module V1
     class IdeasController < ApplicationController
+      def index
+        if params[:category_name]
+          if category = Category.find_by(name: params[:category_name])
+            ideas = category.ideas
+            render status: 200, json: { status: :ok, message: "Selected Category Ideas", data: ideas }
+          else
+            render status: 404, json: { status: :not_found, message: "Category Not Found" }
+          end
+        else
+          ideas = Idea.all.includes(:category)
+          render status: 200, json: { status: :ok, message: "All Ideas", data: ideas }
+        end
+      end
+
       def create
         idea = Idea.new(idea_params)
         if !(params[:category_name].blank? || params[:body].blank?)

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -6,14 +6,15 @@ module Api
       def index
         if params[:category_name]
           if category = Category.find_by(name: params[:category_name])
-            ideas = category.ideas
-            render status: 200, json: { status: :ok, message: "Selected Category Ideas", data: ideas }
+            serialize_ideas(category.ideas)
+            render status: :ok, json: { data: @ideas }
           else
-            render status: 404, json: { status: :not_found, message: "Category Not Found" }
+            render status: :not_found
           end
         else
           ideas = Idea.all.includes(:category)
-          render status: 200, json: { status: :ok, message: "All Ideas", data: ideas }
+          serialize_ideas(ideas)
+          render status: :ok, json: { data: @ideas }
         end
       end
 
@@ -25,15 +26,23 @@ module Api
         end
 
         if idea.save
-          render status: 201, json: { status: :created, data: idea }
+          render status: :created, json: { data: idea }
         else
-          render status: 422, json: { status: :unprocessable_entity, data: idea.errors }
+          render status: :unprocessable_entity, json: { data: idea.errors }
         end
       end
 
       private
         def idea_params
           params.permit(:body, :category_id)
+        end
+
+        def serialize_ideas(ideas)
+          @ideas = []
+          ideas.each do |idea|
+            hash = { id: idea.id, category: idea.category.name, body: idea.body }
+            @ideas = @ideas.push(hash)
+          end
         end
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_11_14_085156) do
-
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_11_14_085156) do
+
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/requests/api/v1/ideas_request_spec.rb
+++ b/spec/requests/api/v1/ideas_request_spec.rb
@@ -3,6 +3,46 @@
 require "rails_helper"
 
 RSpec.describe "IdeasAPI", type: :request do
+  describe "Index" do
+    before do
+      # リクエストするCategoryのideaを生成
+      @category = create(:category)
+      @ideas = create_list(:idea, 3, category: @category)
+      # リクエストするCategoryではないideaを生成
+      other_category = create(:category)
+      @other_idea = create(:idea, category: other_category)
+    end
+
+    context "params:[category_name:]がある場合" do
+      it 'リクエストされたcategoryに対応するideaを取得する' do
+        get '/api/v1/ideas', params: { category_name: @category.name }
+        # @ideasは含まれるが、@other_ideaは含まれない
+        expect(response.body).to include(@ideas.first.body)
+        expect(response.body).not_to include(@other_idea.body)
+        json = JSON.parse(response.body)
+        expect(response.status).to eq(200)
+        expect(json['data'].length).to eq(3)
+      end
+
+      it 'リクエストされたcategoryが存在しない場合' do
+        get '/api/v1/ideas', params: { category_name: "not_exist_category" }
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "params:[category_name:]がない場合" do
+      it '全てのideaを取得する' do
+        get '/api/v1/ideas'
+        # @ideasも@other_ideaも含まれる
+        expect(response.body).to include(@ideas.first.body)
+        expect(response.body).to include(@other_idea.body)
+        json = JSON.parse(response.body)
+        expect(response.status).to eq(200)
+        expect(json['data'].length).to eq(4)
+      end
+    end
+  end
+
   describe "Create" do
     context "paramsが存在する場合" do
       it "既存のCategoryに新しいIdeaを追加する" do

--- a/spec/requests/api/v1/ideas_request_spec.rb
+++ b/spec/requests/api/v1/ideas_request_spec.rb
@@ -14,31 +14,31 @@ RSpec.describe "IdeasAPI", type: :request do
     end
 
     context "params:[category_name:]がある場合" do
-      it 'リクエストされたcategoryに対応するideaを取得する' do
-        get '/api/v1/ideas', params: { category_name: @category.name }
+      it "リクエストされたcategoryに対応するideaを取得する" do
+        get "/api/v1/ideas", params: { category_name: @category.name }
         # @ideasは含まれるが、@other_ideaは含まれない
         expect(response.body).to include(@ideas.first.body)
         expect(response.body).not_to include(@other_idea.body)
         json = JSON.parse(response.body)
         expect(response.status).to eq(200)
-        expect(json['data'].length).to eq(3)
+        expect(json["data"].length).to eq(3)
       end
 
-      it 'リクエストされたcategoryが存在しない場合' do
-        get '/api/v1/ideas', params: { category_name: "not_exist_category" }
+      it "リクエストされたcategoryが存在しない場合" do
+        get "/api/v1/ideas", params: { category_name: "not_exist_category" }
         expect(response.status).to eq(404)
       end
     end
 
     context "params:[category_name:]がない場合" do
-      it '全てのideaを取得する' do
-        get '/api/v1/ideas'
+      it "全てのideaを取得する" do
+        get "/api/v1/ideas"
         # @ideasも@other_ideaも含まれる
         expect(response.body).to include(@ideas.first.body)
         expect(response.body).to include(@other_idea.body)
         json = JSON.parse(response.body)
         expect(response.status).to eq(200)
-        expect(json['data'].length).to eq(4)
+        expect(json["data"].length).to eq(4)
       end
     end
   end


### PR DESCRIPTION
アイデア取得機能を追加するため、indexアクションを作成
【リクエスト】
・category_name(カテゴリー名):string

category_nameが指定されている場合は該当するcategoryのideasの一覧を返却してください。
category_nameが指定されていない場合は

①リクエストのcategory_nameがcategoriesテーブルのnameに存在する場合
→該当するcategoryのideasの一覧を返却（ステータスコード200）
②リクエストのcategory_nameがcategoriesテーブルのnameに存在しない場合
→エラーを返却（ステータスコード404）
③category_nameがリクエストされない場合
→全てのideasを返却（ステータスコード200）

他、以下作業を実行。
・createのレスポンス内に不要なステータス記述があったため削除
・requestスペックの作成